### PR TITLE
Add structures

### DIFF
--- a/src/main/java/com/meti/Compiler.java
+++ b/src/main/java/com/meti/Compiler.java
@@ -10,6 +10,7 @@ import com.meti.render.Field;
 import com.meti.render.Node;
 import com.meti.resolve.MagmaTypeTokenizer;
 import com.meti.type.Type;
+import com.meti.type.TypeGroup;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,7 +58,7 @@ public class Compiler {
     private Type resolve(Type previous) {
         Type parent;
         //TODO: simplify condition
-        if (previous.applyToContent(Function.identity()).isPresent()) {
+        if (previous.applyToContent(Function.identity()).isPresent() && previous.group().test(TypeGroup.Content.matches())) {
             parent = new MagmaTypeTokenizer(previous).tokenize().orElseThrow(() -> invalidateType(previous));
         } else {
             parent = previous;

--- a/src/main/java/com/meti/content/RootContent.java
+++ b/src/main/java/com/meti/content/RootContent.java
@@ -10,6 +10,11 @@ import java.util.stream.Stream;
 public class RootContent implements Content {
     private final String value;
 
+    @Override
+    public String toString() {
+        return value;
+    }
+
     public RootContent(String value) {
         this.value = value;
     }

--- a/src/main/java/com/meti/content/RootContent.java
+++ b/src/main/java/com/meti/content/RootContent.java
@@ -12,7 +12,7 @@ public class RootContent implements Content {
 
     @Override
     public String toString() {
-        return value;
+        return formattedValue();
     }
 
     public RootContent(String value) {
@@ -23,54 +23,54 @@ public class RootContent implements Content {
     public boolean equals(Object o) {
         if (this == o) return true;
         Content that = (Content) o;
-        return that.value().apply(value::equals);
+        return that.value().apply(formattedValue()::equals);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(formattedValue());
     }
 
     @Override
     public Content slice(int start, int end) {
-        String child = value.substring(start, end);
+        String child = formattedValue().substring(start, end);
         String formatted = child.trim();
         return new ChildContent(this, formatted, start, end);
     }
 
     @Override
     public OptionalInt index(String sequence) {
-        int index = value.indexOf(sequence);
+        int index = formattedValue().indexOf(sequence);
         if(index == -1) return OptionalInt.empty();
         else return OptionalInt.of(index);
     }
 
     @Override
     public Content sliceToEnd(int start) {
-        int length = value.length();
+        int length = formattedValue().length();
         return slice(start, length);
     }
 
     @Override
     public OptionalInt indexFrom(String sequence, int end){
-        int index = value.indexOf(sequence, end);
+        int index = formattedValue().indexOf(sequence, end);
         if(index == -1) return OptionalInt.empty();
         return OptionalInt.of(index);
     }
 
     @Override
     public boolean isPresent() {
-        return !value.isBlank();
+        return !formattedValue().isBlank();
     }
 
     @Override
     public int length(){
-        return value.length();
+        return formattedValue().length();
     }
 
     @Override
     public char apply(int index){
-        return value.charAt(index);
+        return formattedValue().charAt(index);
     }
 
     @Override
@@ -80,17 +80,21 @@ public class RootContent implements Content {
 
     @Override
     public Monad<String> value(){
-        return new Monad<>(value);
+        return new Monad<>(formattedValue());
+    }
+
+    private String formattedValue() {
+        return value.trim();
     }
 
     @Override
     public boolean startsWith(String sequence) {
-        return value.startsWith(sequence);
+        return formattedValue().startsWith(sequence);
     }
 
     @Override
     public boolean endsWith(String sequence) {
-        return value.endsWith(sequence);
+        return formattedValue().endsWith(sequence);
     }
 
     @Override

--- a/src/main/java/com/meti/evaluate/tokenizer/BlockNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/BlockNodeTokenizer.java
@@ -51,6 +51,7 @@ public class BlockNodeTokenizer extends AbstractNodeTokenizer {
                     complete();
                 } else if (c == '}' && depth == 1) {
                     buffer.append('}');
+                    depth--;
                     complete();
                 } else {
                     if (c == '{') depth++;

--- a/src/main/java/com/meti/evaluate/tokenizer/ConstructionTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/ConstructionTokenizer.java
@@ -1,0 +1,56 @@
+package com.meti.evaluate.tokenizer;
+
+import com.meti.content.Content;
+import com.meti.content.RootContent;
+import com.meti.content.Strategy;
+import com.meti.render.ConstructionNode;
+import com.meti.render.ContentNode;
+import com.meti.render.Node;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ConstructionTokenizer extends AbstractNodeTokenizer {
+    public ConstructionTokenizer(Content content) {
+        super(content);
+    }
+
+    @Override
+    public Optional<Node> evaluate() {
+        if (content.startsWith("<") && content.endsWith("}")) {
+            OptionalInt optional = content.index("{");
+            if (optional.isPresent()) {
+                int separator = optional.getAsInt();
+                Content slice = content.slice(separator + 1, content.length() - 1);
+                List<Node> children = slice.split(ConstructionStrategy::new)
+                        .filter(Content::isPresent)
+                        .map(ContentNode::new)
+                        .collect(Collectors.toList());
+                return Optional.of(new ConstructionNode(children));
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static class ConstructionStrategy implements Strategy {
+        private final Content content;
+
+        public ConstructionStrategy(Content content) {
+            this.content = content;
+        }
+
+        @Override
+        public Stream<Content> split() {
+            return content.value()
+                    .map(value -> value.split(","))
+                    .apply(Arrays::stream)
+                    .map(RootContent::new);
+        }
+    }
+}

--- a/src/main/java/com/meti/evaluate/tokenizer/FieldNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/FieldNodeTokenizer.java
@@ -1,0 +1,28 @@
+package com.meti.evaluate.tokenizer;
+
+import com.meti.content.Content;
+import com.meti.render.ContentNode;
+import com.meti.render.FieldNode;
+import com.meti.render.Node;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class FieldNodeTokenizer extends AbstractNodeTokenizer {
+    public FieldNodeTokenizer(Content content) {
+        super(content);
+    }
+
+    @Override
+    public Optional<Node> evaluate() {
+        OptionalInt separatorOptional = content.index(".");
+        if (separatorOptional.isPresent()) {
+            int separator = separatorOptional.getAsInt();
+            Content parentContent = content.slice(0, separator);
+            Node parent = new ContentNode(parentContent);
+            Content fieldName = content.sliceToEnd(separator + 1);
+            return Optional.of(new FieldNode(parent, fieldName));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
@@ -25,6 +25,7 @@ public class MagmaNodeTokenizer extends CollectiveNodeTokenizer {
                 FunctionNodeTokenizer::new,
                 IntegerNodeTokenizer::new,
                 DeclareNodeTokenizer::new,
+                FieldNodeTokenizer::new,
                 VariableNodeTokenizer::new
         );
     }

--- a/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
@@ -15,6 +15,7 @@ public class MagmaNodeTokenizer extends CollectiveNodeTokenizer {
     @Override
     protected Stream<Function<Content, Evaluator<Node>>> streamFactories() {
         return Stream.of(
+                StructureNodeTokenizer::new,
                 DereferenceNodeTokenizer::new,
                 ReferenceNodeTokenizer::new,
                 ReturnNodeTokenizer::new,

--- a/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/MagmaNodeTokenizer.java
@@ -15,6 +15,7 @@ public class MagmaNodeTokenizer extends CollectiveNodeTokenizer {
     @Override
     protected Stream<Function<Content, Evaluator<Node>>> streamFactories() {
         return Stream.of(
+                ConstructionTokenizer::new,
                 StructureNodeTokenizer::new,
                 DereferenceNodeTokenizer::new,
                 ReferenceNodeTokenizer::new,

--- a/src/main/java/com/meti/evaluate/tokenizer/StructureNodeTokenizer.java
+++ b/src/main/java/com/meti/evaluate/tokenizer/StructureNodeTokenizer.java
@@ -1,0 +1,60 @@
+package com.meti.evaluate.tokenizer;
+
+import com.meti.content.Content;
+import com.meti.content.RootContent;
+import com.meti.content.Strategy;
+import com.meti.evaluate.FieldEvaluator;
+import com.meti.render.Field;
+import com.meti.render.Node;
+import com.meti.render.StructureNode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StructureNodeTokenizer extends AbstractNodeTokenizer{
+    public StructureNodeTokenizer(Content content) {
+        super(content);
+    }
+
+    @Override
+    public Optional<Node> evaluate() {
+        if(content.startsWith("struct ") && content.endsWith("}")) {
+            OptionalInt separatorOptional = content.index("{");
+            if(separatorOptional.isPresent()) {
+                int separator = separatorOptional.getAsInt();
+                Content name = content.slice(7, separator);
+                Content fieldString = content.slice(separator + 1, content.length() - 1);
+                List<Field> fields = fieldString.split(FieldStrategy::new)
+                        .filter(Content::isPresent)
+                        .map(FieldEvaluator::new)
+                        .map(FieldEvaluator::evaluate)
+                        .map(Optional::orElseThrow)
+                        .collect(Collectors.toList());
+                return Optional.of(new StructureNode(name, fields));
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static class FieldStrategy implements Strategy {
+        private final Content content;
+
+        public FieldStrategy(Content content) {
+            this.content = content;
+        }
+
+        @Override
+        public Stream<Content> split() {
+            return content.value()
+                    .map(s-> s.split(";"))
+                    .apply(Arrays::stream)
+                    .map(RootContent::new);
+        }
+    }
+}

--- a/src/main/java/com/meti/render/ConstructionNode.java
+++ b/src/main/java/com/meti/render/ConstructionNode.java
@@ -1,0 +1,82 @@
+package com.meti.render;
+
+import com.meti.content.Content;
+import com.meti.util.Monad;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ConstructionNode extends ParentNode {
+    private final List<Node> children;
+
+    public ConstructionNode(List<Node> children) {
+        this.children = children;
+    }
+
+    @Override
+    public <R> Optional<R> applyToContent(Function<Content, R> function) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Monad<NodeGroup> group() {
+        return new Monad<>(NodeGroup.Construction);
+    }
+
+    @Override
+    public Stream<Field> streamFields() {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<Node> streamChildren() {
+        return children.stream();
+    }
+
+    @Override
+    public Prototype createPrototype() {
+        return new ConstructionPrototype();
+    }
+
+    @Override
+    public Optional<String> render() {
+        return Optional.of(children.stream()
+                .map(Node::render)
+                .map(Optional::orElseThrow)
+                .collect(Collectors.joining(",", "{" ,"}")));
+    }
+
+    private static class ConstructionPrototype implements Prototype {
+        private final List<Node> children;
+
+        private ConstructionPrototype() {
+            this(Collections.emptyList());
+        }
+
+        private ConstructionPrototype(List<Node> children) {
+            this.children = children;
+        }
+
+        @Override
+        public Prototype withField(Field field) {
+            return this;
+        }
+
+        @Override
+        public Prototype withChild(Node child) {
+            List<Node> newChildren = new ArrayList<>(children);
+            newChildren.add(child);
+            return new ConstructionPrototype(newChildren);
+        }
+
+        @Override
+        public Node build() {
+            return new ConstructionNode(children);
+        }
+    }
+}

--- a/src/main/java/com/meti/render/FieldNode.java
+++ b/src/main/java/com/meti/render/FieldNode.java
@@ -1,0 +1,77 @@
+package com.meti.render;
+
+import com.meti.content.Content;
+import com.meti.util.Monad;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class FieldNode extends ParentNode{
+    private final Content fieldName;
+    private final Node parent;
+
+    public FieldNode(Node parent, Content fieldName) {
+        this.fieldName = fieldName;
+        this.parent = parent;
+    }
+
+    @Override
+    public <R> Optional<R> applyToContent(Function<Content, R> function) {
+        return Optional.of(fieldName).map(function);
+    }
+
+    @Override
+    public Monad<NodeGroup> group() {
+        return new Monad<>(NodeGroup.Field);
+    }
+
+    @Override
+    public Stream<Field> streamFields() {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<Node> streamChildren() {
+        return Stream.of(parent);
+    }
+
+    @Override
+    public Prototype createPrototype() {
+        return new FieldNodePrototype(fieldName, parent);
+    }
+
+    @Override
+    public Optional<String> render() {
+        return Optional.of(parent.render().orElseThrow() + "." + fieldName.value().apply(Function.identity()));
+    }
+
+    private static class FieldNodePrototype implements Prototype {
+        private final Content fieldName;
+        private final Node parent;
+
+        private FieldNodePrototype(Content fieldName) {
+            this(fieldName, null);
+        }
+
+        private FieldNodePrototype(Content fieldName, Node parent) {
+            this.fieldName = fieldName;
+            this.parent = parent;
+        }
+
+        @Override
+        public Prototype withField(Field field) {
+            return this;
+        }
+
+        @Override
+        public Prototype withChild(Node child) {
+            return new FieldNodePrototype(fieldName, child);
+        }
+
+        @Override
+        public Node build() {
+            return new FieldNode(parent, fieldName);
+        }
+    }
+}

--- a/src/main/java/com/meti/render/NodeGroup.java
+++ b/src/main/java/com/meti/render/NodeGroup.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 
 public enum NodeGroup {
     ConcreteFunction,
-    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure, Structure, Construction;
+    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure, Structure, Construction, Field;
 
     public Predicate<NodeGroup> matches() {
         return (NodeGroup group) -> group == this;

--- a/src/main/java/com/meti/render/NodeGroup.java
+++ b/src/main/java/com/meti/render/NodeGroup.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 
 public enum NodeGroup {
     ConcreteFunction,
-    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure, Structure;
+    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure, Structure, Construction;
 
     public Predicate<NodeGroup> matches() {
         return (NodeGroup group) -> group == this;

--- a/src/main/java/com/meti/render/NodeGroup.java
+++ b/src/main/java/com/meti/render/NodeGroup.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 
 public enum NodeGroup {
     ConcreteFunction,
-    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure;
+    Variable, Block, Return, Integer, Declare, Reference, Dereference, AbstractFunction, Mapping, Procedure, Structure;
 
     public Predicate<NodeGroup> matches() {
         return (NodeGroup group) -> group == this;

--- a/src/main/java/com/meti/render/StructureNode.java
+++ b/src/main/java/com/meti/render/StructureNode.java
@@ -1,0 +1,105 @@
+package com.meti.render;
+
+import com.meti.content.Content;
+import com.meti.content.RootContent;
+import com.meti.type.StructureType;
+import com.meti.type.Type;
+import com.meti.util.Monad;
+import com.meti.util.TriFunction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StructureNode implements Node {
+    private final Content name;
+    private final List<Field> fields;
+
+    public StructureNode(Content name, List<Field> fields) {
+        this.name = name;
+        this.fields = fields;
+    }
+
+    @Override
+    public <R> Optional<R> applyToContent(Function<Content, R> function) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isParent() {
+        return false;
+    }
+
+    @Override
+    public Monad<NodeGroup> group() {
+        return new Monad<>(NodeGroup.Structure);
+    }
+
+    @Override
+    public Stream<Field> streamFields() {
+        return Stream.of(createIdentity());
+    }
+
+    private Field createIdentity() {
+        return name.value().apply(this::createIdentity);
+    }
+
+    private InlineField createIdentity(String name) {
+        return new InlineField(name, new StructureType(this.name, fields), Collections.emptyList());
+    }
+
+    @Override
+    public Stream<Node> streamChildren() {
+        return Stream.empty();
+    }
+
+    @Override
+    public Prototype createPrototype() {
+        return new StructureNodePrototype();
+    }
+
+    @Override
+    public Optional<String> render() {
+        return Optional.of("struct " + name + fields.stream()
+                .map(Renderable::render)
+                .map(Optional::orElseThrow)
+                .map(value -> value + ";")
+                .collect(Collectors.joining("", "{", "}")) + ";");
+    }
+
+    private static class StructureNodePrototype implements Prototype {
+        private final Field identity;
+
+        private StructureNodePrototype() {
+            this(null);
+        }
+
+        private StructureNodePrototype(Field identity) {
+            this.identity = identity;
+        }
+
+        @Override
+        public Prototype withField(Field field) {
+            return new StructureNodePrototype(field);
+        }
+
+        @Override
+        public Prototype withChild(Node child) {
+            return this;
+        }
+
+        @Override
+        public Node build() {
+            if (identity == null) throw new IllegalStateException("Identity is null.");
+            return identity.destroy().apply((TriFunction<String, Type, List<FieldFlag>, Node>) (s, type, fieldFlags) -> getStructureNode(s, type));
+        }
+
+        private StructureNode getStructureNode(String s, Type type) {
+            List<Field> fields = type.streamFields().collect(Collectors.toList());
+            return new StructureNode(new RootContent(s), fields);
+        }
+    }
+}

--- a/src/main/java/com/meti/resolve/MagmaTypeTokenizer.java
+++ b/src/main/java/com/meti/resolve/MagmaTypeTokenizer.java
@@ -15,6 +15,7 @@ public class MagmaTypeTokenizer extends CompoundTypeTokenizer {
         return Stream.of(
                 StringTypeTokenizer::new,
                 PrimitiveTypeTokenizer::new,
-                PointerTypeTokenizer::new);
+                PointerTypeTokenizer::new,
+                StructTypeTokenizer::new);
     }
 }

--- a/src/main/java/com/meti/resolve/PointerType.java
+++ b/src/main/java/com/meti/resolve/PointerType.java
@@ -3,6 +3,8 @@ package com.meti.resolve;
 import com.meti.content.Content;
 import com.meti.render.Field;
 import com.meti.type.Type;
+import com.meti.type.TypeGroup;
+import com.meti.util.Monad;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -38,5 +40,10 @@ class PointerType implements Type {
     @Override
     public Stream<Field> streamFields() {
         return Stream.empty();
+    }
+
+    @Override
+    public Monad<TypeGroup> group(){
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/com/meti/resolve/StructTypeTokenizer.java
+++ b/src/main/java/com/meti/resolve/StructTypeTokenizer.java
@@ -1,0 +1,17 @@
+package com.meti.resolve;
+
+import com.meti.type.StructureType;
+import com.meti.type.Type;
+
+import java.util.Optional;
+
+public class StructTypeTokenizer extends AbstractTypeTokenizer {
+    public StructTypeTokenizer(Type previous) {
+        super(previous);
+    }
+
+    @Override
+    public Optional<Type> tokenize() {
+        return previous.applyToContent(StructureType::new);
+    }
+}

--- a/src/main/java/com/meti/type/ContentType.java
+++ b/src/main/java/com/meti/type/ContentType.java
@@ -2,6 +2,7 @@ package com.meti.type;
 
 import com.meti.content.Content;
 import com.meti.render.Field;
+import com.meti.util.Monad;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -37,5 +38,10 @@ public class ContentType implements Type {
     @Override
     public Stream<Field> streamFields(){
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Monad<TypeGroup> group(){
+        return new Monad<>(TypeGroup.Content);
     }
 }

--- a/src/main/java/com/meti/type/FormattedType.java
+++ b/src/main/java/com/meti/type/FormattedType.java
@@ -2,6 +2,7 @@ package com.meti.type;
 
 import com.meti.content.Content;
 import com.meti.render.Field;
+import com.meti.util.Monad;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -32,6 +33,11 @@ public abstract class FormattedType implements Type {
 
     @Override
     public Stream<Field> streamFields(){
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Monad<TypeGroup> group(){
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/com/meti/type/PrimitiveType.java
+++ b/src/main/java/com/meti/type/PrimitiveType.java
@@ -2,6 +2,7 @@ package com.meti.type;
 
 import com.meti.content.Content;
 import com.meti.render.Field;
+import com.meti.util.Monad;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -52,6 +53,11 @@ public enum PrimitiveType implements Type {
     @Override
     public Stream<Field> streamFields() {
         return Stream.empty();
+    }
+
+    @Override
+    public Monad<TypeGroup> group(){
+        throw new UnsupportedOperationException();
     }
 
     private class PrimitivePrototype implements Prototype {

--- a/src/main/java/com/meti/type/StructureType.java
+++ b/src/main/java/com/meti/type/StructureType.java
@@ -1,0 +1,82 @@
+package com.meti.type;
+
+import com.meti.content.Content;
+import com.meti.render.Field;
+import com.meti.util.Monad;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class StructureType implements Type {
+    private final Content name;
+    private final List<Field> fields;
+
+    public StructureType(Content name, List<Field> fields) {
+        this.name = name;
+        this.fields = fields;
+    }
+
+    @Override
+    public <R> Optional<R> applyToContent(Function<Content, R> function) {
+        return Optional.of(name).map(function);
+    }
+
+    @Override
+    public Optional<String> render(String name) {
+        return this.name.value().map(inner -> "struct " + inner + " " + name).toOption();
+    }
+
+    @Override
+    public Prototype createPrototype() {
+        return new StructureTypePrototype(name);
+    }
+
+    @Override
+    public Stream<Type> streamChildren() {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<Field> streamFields() {
+        return fields.stream();
+    }
+
+    @Override
+    public Monad<TypeGroup> group(){
+        return new Monad<>(TypeGroup.Structure);
+    }
+
+    private static class StructureTypePrototype implements Prototype {
+        private final List<Field> fields;
+        private final Content name;
+
+        private StructureTypePrototype(Content name) {
+            this(name, new ArrayList<>());
+        }
+
+        private StructureTypePrototype(Content name, List<Field> fields) {
+            this.name = name;
+            this.fields = fields;
+        }
+
+        @Override
+        public Prototype withChild(Type child) {
+            return this;
+        }
+
+        @Override
+        public Prototype withField(Field field) {
+            List<Field> newFields = new ArrayList<>(fields);
+            newFields.add(field);
+            return new StructureTypePrototype(name, newFields);
+        }
+
+        @Override
+        public Type build() {
+            return new StructureType(name, fields);
+        }
+    }
+}

--- a/src/main/java/com/meti/type/StructureType.java
+++ b/src/main/java/com/meti/type/StructureType.java
@@ -5,6 +5,7 @@ import com.meti.render.Field;
 import com.meti.util.Monad;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -17,6 +18,10 @@ public class StructureType implements Type {
     public StructureType(Content name, List<Field> fields) {
         this.name = name;
         this.fields = fields;
+    }
+
+    public StructureType(Content name) {
+        this(name, Collections.emptyList());
     }
 
     @Override
@@ -45,7 +50,7 @@ public class StructureType implements Type {
     }
 
     @Override
-    public Monad<TypeGroup> group(){
+    public Monad<TypeGroup> group() {
         return new Monad<>(TypeGroup.Structure);
     }
 

--- a/src/main/java/com/meti/type/Type.java
+++ b/src/main/java/com/meti/type/Type.java
@@ -2,12 +2,15 @@ package com.meti.type;
 
 import com.meti.content.Content;
 import com.meti.render.Field;
+import com.meti.util.Monad;
 
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 public interface Type {
+    Monad<TypeGroup> group();
+
     <R> Optional<R> applyToContent(Function<Content, R> function);
 
     Optional<String> render(String name);

--- a/src/main/java/com/meti/type/TypeGroup.java
+++ b/src/main/java/com/meti/type/TypeGroup.java
@@ -1,0 +1,11 @@
+package com.meti.type;
+
+import java.util.function.Predicate;
+
+public enum TypeGroup {
+    Content, Structure;
+
+    public Predicate<TypeGroup> matches() {
+        return typeGroup -> typeGroup == this;
+    }
+}

--- a/src/test/java/com/meti/StructureTest.java
+++ b/src/test/java/com/meti/StructureTest.java
@@ -20,16 +20,16 @@ public class StructureTest extends CompileTest {
 
     @Test
     void emptyConstruct() {
-        assertCompile("", "struct Empty{}def main() : I16 => {const value : Empty = <Empty>{}}; return 0;}");
+        assertCompile("struct Empty{};int main(){struct Empty value={};return 0;}", "struct Empty{}def main() : I16 => {const value : Empty = <Empty>{}; return 0;}");
     }
 
     @Test
     void singleConstruct() {
-        assertCompile("", "struct Wrapper{value : I16}def main() : I16 => {const value : Wrapper = <Wrapper>{16}; return 0;}");
+        assertCompile("struct Wrapper{int value;};int main(){struct Wrapper value={16};return 0;}", "struct Wrapper{value : I16}def main() : I16 => {const value : Wrapper = <Wrapper>{16}; return 0;}");
     }
 
     @Test
     void multipleConstruct() {
-        assertCompile("", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {const value : Pair = <Pair>{2, 2}; return 0;}");
+        assertCompile("struct Pair{unsigned char value0;unsigned int value1;};int main(){struct Pair value={2,2};return 0;}", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {const value : Pair = <Pair>{2, 2}; return 0;}");
     }
 }

--- a/src/test/java/com/meti/StructureTest.java
+++ b/src/test/java/com/meti/StructureTest.java
@@ -1,0 +1,35 @@
+package com.meti;
+
+import org.junit.jupiter.api.Test;
+
+public class StructureTest extends CompileTest {
+    @Test
+    void emptyDefine() {
+        assertCompile("", "struct Empty{}def main() : I16 => {return 0;}");
+    }
+
+    @Test
+    void singleDefine() {
+        assertCompile("", "struct Wrapper{value : I16}def main() : I16 => {return 0;}");
+    }
+
+    @Test
+    void multipleDefine() {
+        assertCompile("", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {return 0;}");
+    }
+
+    @Test
+    void emptyConstruct() {
+        assertCompile("", "struct Empty{}def main() : I16 => {const value : Empty = <Empty>{}}; return 0;}");
+    }
+
+    @Test
+    void singleConstruct() {
+        assertCompile("", "struct Wrapper{value : I16}def main() : I16 => {const value : Wrapper = <Wrapper>{16}; return 0;}");
+    }
+
+    @Test
+    void multipleConstruct() {
+        assertCompile("", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {const value : Pair = <Pair>{2, 2}; return 0;}");
+    }
+}

--- a/src/test/java/com/meti/StructureTest.java
+++ b/src/test/java/com/meti/StructureTest.java
@@ -32,4 +32,9 @@ public class StructureTest extends CompileTest {
     void multipleConstruct() {
         assertCompile("struct Pair{unsigned char value0;unsigned int value1;};int main(){struct Pair value={2,2};return 0;}", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {const value : Pair = <Pair>{2, 2}; return 0;}");
     }
+
+    @Test
+    void fields(){
+        assertCompile("struct Wrapper{int value;};int main(){struct Wrapper instance={0};return instance.value;}", "struct Wrapper{value : I16}def main() : I16 => {const instance : Wrapper = {0};return instance.value;}");
+    }
 }

--- a/src/test/java/com/meti/StructureTest.java
+++ b/src/test/java/com/meti/StructureTest.java
@@ -5,17 +5,17 @@ import org.junit.jupiter.api.Test;
 public class StructureTest extends CompileTest {
     @Test
     void emptyDefine() {
-        assertCompile("", "struct Empty{}def main() : I16 => {return 0;}");
+        assertCompile("struct Empty{};int main(){return 0;}", "struct Empty{}def main() : I16 => {return 0;}");
     }
 
     @Test
     void singleDefine() {
-        assertCompile("", "struct Wrapper{value : I16}def main() : I16 => {return 0;}");
+        assertCompile("struct Wrapper{int value;};int main(){return 0;}", "struct Wrapper{value : I16}def main() : I16 => {return 0;}");
     }
 
     @Test
     void multipleDefine() {
-        assertCompile("", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {return 0;}");
+        assertCompile("strCuct Pair{unsigned char value0;unsigned int value1;};int main(){return 0;}", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {return 0;}");
     }
 
     @Test

--- a/src/test/java/com/meti/StructureTest.java
+++ b/src/test/java/com/meti/StructureTest.java
@@ -15,7 +15,7 @@ public class StructureTest extends CompileTest {
 
     @Test
     void multipleDefine() {
-        assertCompile("strCuct Pair{unsigned char value0;unsigned int value1;};int main(){return 0;}", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {return 0;}");
+        assertCompile("struct Pair{unsigned char value0;unsigned int value1;};int main(){return 0;}", "struct Pair{value0 : U8;value1 : U16}def main() : I16 => {return 0;}");
     }
 
     @Test


### PR DESCRIPTION
Added a few features that resemble/actually are C structures. This isn't unusual for higher level languages, i.e. Scala has case classes and TypeScript has interfaces that can mimic what these formations actually do.

**Defining**
```
struct Point {
  const x : I16;
  const y : I16;
}
```
Notice that, unlike C, the structure doesn't end in a semicolon (because that seemed somewhat stupid from a design standpoint.)

**Construction**
```
def main() : Int => {
  const myPoint : Point = <Point>{3, 4};
  return 0;
}
```
This is a mashup of TypeScript interface creation and C structures.

**Field Accessing**
```
def main() : Int => {
  const myPoint : Point = <Point>{3, 4};
  const x = myPoint.x;
  const y = myPoint.y;
  return 0;
}
```
Fairly straightforward, what would you expect?